### PR TITLE
Add: unofficial implement of PyTorch NPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Other unofficial implementations:
 
 + ShiftViT
   + [Keras](https://keras.io/examples/vision/shiftvit/) by [Aritra Roy Gosthipaty](https://twitter.com/ariG23498) and [Ritwik Raha](https://twitter.com/ritwik_raha)
-
++ SPACH
+  + [PyTorch with NPU](https://github.com/Leoooo333/SPACH-1) by [Junming Chen](https://github.com/Leoooo333)
 # Main Results on ImageNet with Pretrained Models
 
 


### PR DESCRIPTION
Transfer SPACH model from GPU to Ascend NPU(PyTorch). Use the '--npu' argument to enable NPU. If not, the model will still run on GPU.